### PR TITLE
Fix for FormTypeValidatorExtension for Symfony 4.2

### DIFF
--- a/src/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
+++ b/src/Form/Extension/Validator/Type/FormTypeValidatorExtension.php
@@ -18,6 +18,7 @@ use Symfony\Component\Form\Extension\Validator\EventListener\ValidationListener;
 use Symfony\Component\Validator\Validator\ValidatorInterface;
 use Symfony\Component\OptionsResolver\Options;
 use Symfony\Component\OptionsResolver\OptionsResolver;
+use Symfony\Component\Form\Extension\Core\Type\FormType;
 
 /**
  * @author Sven Wappler
@@ -71,5 +72,14 @@ class FormTypeValidatorExtension extends BaseValidatorExtension
     public function getExtendedType()
     {
         return 'Symfony\Component\Form\Extension\Core\Type\FormType';
+    }
+    
+    /**
+    * @link https://symfony.com/blog/new-in-symfony-4-2-improved-form-type-extensions
+    * {@inheritdoc}
+    */
+    public function getExtendedTypes(): iterable
+    {
+		return [FormType::class];
     }
 }


### PR DESCRIPTION
Symfony 4.2 needs the function getExtendedTypes() 
https://symfony.com/blog/new-in-symfony-4-2-improved-form-type-extensions

Otherwise this error comes
(1/1) InvalidArgumentException
"form.type_extension" tagged services have to implement the static getExtendedTypes() method. The class for service "App\Form\Extension\Validator\Type\FormTypeValidatorExtension" does not implement it.